### PR TITLE
Update Keyvault-secrets Readme

### DIFF
--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -75,7 +75,7 @@ Use the [Azure Cloud Shell](https://shell.azure.com/bash) snippet below to creat
 - Grant the above mentioned application authorization to perform secret operations on the keyvault:
 
   ```Bash
-  az keyvault set-policy --name <your-key-vault-name> --spn $AZURE_CLIENT_ID --secret-permissions backup delete get list create
+  az keyvault set-policy --name <your-key-vault-name> --spn $AZURE_CLIENT_ID --secret-permissions backup delete get list set
   ```
 
   > --secret-permissions:
@@ -160,9 +160,9 @@ optional parameters.
 
 ```javascript
 const latestSecret = await client.getSecret(secretName);
-console.log(`Latest version of the secret ${secretName}: `, getResult);
+console.log(`Latest version of the secret ${secretName}: `, latestSecret);
 const specificSecret = await client.getSecret(secretName, { version: latestSecret.version! });
-console.log(`The secret ${secretName} at the version ${latestSecret.version!}: `, getResult);
+console.log(`The secret ${secretName} at the version ${latestSecret.version!}: `, specificSecret);
 ```
 
 ### Creating and updating secrets with attributes

--- a/sdk/keyvault/keyvault-secrets/README.md
+++ b/sdk/keyvault/keyvault-secrets/README.md
@@ -79,7 +79,7 @@ Use the [Azure Cloud Shell](https://shell.azure.com/bash) snippet below to creat
   ```
 
   > --secret-permissions:
-  > Accepted values: backup, delete, get, list, purge, recover, restore, create
+  > Accepted values: backup, delete, get, list, purge, recover, restore, set
 
 - Use the above mentioned Key Vault name to retrieve details of your Vault which also contains your Key Vault URL:
   ```Bash


### PR DESCRIPTION
**Purpose** :  update readme based on Preview3
**Total changes** : 2 
### 1. The permissions of secret don't have the value of create
This part changes the create as set when getting the permissions of secret
**Original**
![批注 2019-09-25 104139](https://user-images.githubusercontent.com/20970631/65564976-2ff6f600-df81-11e9-888f-f2b8d955e4e4.png)
**Proposal**
![65565016-4c932e00-df81-11e9-96e4-2dcbd083532a](https://user-images.githubusercontent.com/20970631/65574832-09e14e00-dfa1-11e9-9cb2-750bd5df8e10.png)

### 2. Incorrect variable "getResult"
This part uses the variable which is created instead of the variable which is non-existent when getting a secret
**Original**
![65565300-14401f80-df82-11e9-89d9-8997210c8d6d](https://user-images.githubusercontent.com/20970631/65574929-414ffa80-dfa1-11e9-99c6-16973b486c6e.png)
**Proposal**
![65565388-5e290580-df82-11e9-9843-f377ff0e6153](https://user-images.githubusercontent.com/20970631/65575079-8aa04a00-dfa1-11e9-940d-595458a23a1e.png)
